### PR TITLE
dotty support for linearize; make Linearized repo loadable in sbt

### DIFF
--- a/sbtLinearizeCommands/Man.scala.template
+++ b/sbtLinearizeCommands/Man.scala.template
@@ -1,0 +1,97 @@
+package sbtstudent
+
+/**
+  * Copyright © 2014, 2015, 2016 Lightbend, Inc. All rights reserved. [http://www.typesafe.com]
+  */
+
+import sbt.Keys._
+import sbt._
+import sbt.complete.DefaultParsers._
+
+import scala.Console
+import scala.util.matching._
+
+object Man {
+  val manDetail: String = "Displays the README.md file. Use <noarg> for setup README.md or <e> for exercise README.md"
+
+  lazy val optArg = OptSpace ~> StringBasic.?
+
+  def man: Command = Command("man")(_ => optArg) { (state, arg) =>
+    arg match {
+      case Some(a) if a == "e" =>
+        val base: File = Project.extract(state).get(sourceDirectory)
+        val readmeFile: File = {
+          val bPath = new File(base, "/test/resources/README.md")
+          if (bPath.isFile) bPath else new File(base, "../README.md")
+        }
+        printOut(readmeFile)
+        Console.print("\n")
+        state
+      case Some(a) =>
+        Console.print("\n")
+        Console.println(Console.RED + "[ERROR] " + Console.RESET + "invalid argument " + Console.RED + a + Console.RESET  + ". " + manDetail)
+        Console.print("\n")
+        state
+      case None =>
+        val base: File = Project.extract(state).get(baseDirectory)
+        val readMeFile = new sbt.File(new sbt.File(Project.extract(state).structure.root), "README.md")
+        printOut(readMeFile)
+        Console.print("\n")
+        state
+    }
+  }
+
+  val bulletRx: Regex = """- """.r
+  val boldRx: Regex = """(\*\*)(\w*)(\*\*)""".r
+  val codeRx: Regex = """(`)([^`]+)(`)""".r
+  val fenceStartRx: Regex = """^```(bash|scala)$""".r
+  val fenceEndRx: Regex = """^```$""".r
+  val numberRx: Regex = """^(\d{1,3})(\. )""".r
+  val urlRx: Regex = """(\()(htt[a-zA-Z0-9\-\.\/:]*)(\))""".r
+  val ConBlue = Console.BLUE
+  val ConGreen = Console.GREEN
+  val ConMagenta = Console.MAGENTA
+  val ConRed = Console.RED
+  val ConReset = Console.RESET
+  val ConYellow = Console.YELLOW
+
+  def printOut(path: File) {
+    var inCodeFence = false
+    IO.readLines(path) foreach {
+      case ln if !inCodeFence && ln.length > 0 && ln(0).equals('#') =>
+        Console.println(ConRed + ln + ConReset)
+      case ln if !inCodeFence && ln.matches(".*" + bulletRx.toString() + ".*") =>
+        val lne = bulletRx replaceAllIn (ln, ConRed + bulletRx.toString() + ConReset)
+        Console.println(rxFormat(rxFormat(rxFormat(lne, codeRx, ConGreen), boldRx, ConYellow), urlRx, ConMagenta,
+          keepWrapper = true))
+      case ln if !inCodeFence && ln.matches(numberRx.toString() + ".*") =>
+        val lne = numberRx replaceAllIn (ln, _ match { case numberRx(n, s) => f"$ConRed$n$s$ConReset" })
+        Console.println(rxFormat(rxFormat(lne, codeRx, ConGreen), boldRx, ConYellow))
+      case ln if ln.matches(fenceStartRx.toString()) =>
+        inCodeFence = true
+        Console.print(ConGreen)
+      case ln if ln.matches(fenceEndRx.toString()) =>
+        inCodeFence = false
+        Console.print(ConReset)
+      case ln =>
+        Console.println(rxFormat(rxFormat(rxFormat(ln, codeRx, ConGreen), boldRx, ConYellow), urlRx, ConMagenta,
+          keepWrapper = true))
+    }
+  }
+
+  def rxFormat(ln: String, rx: Regex, startColor: String, keepWrapper: Boolean = false): String = ln match {
+    case `ln` if ln.matches(".*" + rx.toString + ".*") =>
+      val lne = rx replaceAllIn (ln, _ match {
+        case rx(start, in, stop) =>
+          if (keepWrapper)
+            f"$start$startColor$in$ConReset$stop"
+          else
+            f"$startColor$in$ConReset"
+      })
+      lne
+    case _ =>
+      ln
+  }
+
+}
+

--- a/sbtLinearizeCommands/Navigation.scala.template
+++ b/sbtLinearizeCommands/Navigation.scala.template
@@ -1,0 +1,30 @@
+package sbtstudent
+
+/**
+  * Copyright © 2014, 2015, 2016 Lightbend, Inc. All rights reserved. [http://www.typesafe.com]
+  */
+
+import sbt._
+import scala.Console
+import sbtstudent.StudentKeys._
+
+object Navigation {
+
+  val setupNavAttrs: State => State = (s: State) => {
+    val mark: File = s get bookmark getOrElse new sbt.File(new sbt.File(Project.extract(s).structure.root), ".bookmark")
+    s.put(bookmark, mark)
+  }
+
+  val loadBookmark: (State) => State = (state: State) => {
+    val key: AttributeKey[File] = AttributeKey[File](bookmarkKeyName)
+    val bookmarkFile: Option[File] = state get key
+    try {
+      val mark: String = IO.read(bookmarkFile.get).strip()
+      val cmd: String = s"project $mark"
+      val newState = cmd :: state
+      newState
+    } catch {
+      case e: java.io.FileNotFoundException => state
+    }
+  }
+}

--- a/sbtLinearizeCommands/StudentCommandsPlugin.scala.template
+++ b/sbtLinearizeCommands/StudentCommandsPlugin.scala.template
@@ -1,0 +1,48 @@
+package sbtstudent
+
+import sbt.Keys._
+import sbt.{Def, _}
+import stbstudent.MPSelection
+
+import scala.Console
+
+object StudentCommandsPlugin extends AutoPlugin {
+
+  override val requires = sbt.plugins.JvmPlugin
+  override val trigger: PluginTrigger = allRequirements
+  object autoImport {
+  }
+  override lazy val globalSettings =
+    Seq(
+      commands in Global ++=
+        Seq(
+          Man.man, MPSelection.setActiveExerciseNr
+        ),
+      onLoad in Global := {
+        val state = (onLoad in Global).value
+        Navigation.loadBookmark compose(Navigation.setupNavAttrs compose state)
+      }
+    )
+
+  def extractCurrentExerciseDesc(state: State): String = {
+    val currentExercise =  Project.extract(state).currentProject.id
+
+    currentExercise
+      .replaceFirst("""^.*_\d{3}_""", "")
+      .replaceAll("_", " ")
+  }
+
+  def extractProjectName(state: State): String = {
+    IO.readLines(new sbt.File(new sbt.File(Project.extract(state).structure.root), ".courseName")).head
+  }
+
+  override lazy val projectSettings: Seq[Def.Setting[State => String]] =
+    Seq(
+      shellPrompt := { state =>
+        val exercise = Console.GREEN + extractCurrentExerciseDesc(state) + Console.RESET
+        val manRmnd = Console.GREEN + "man [e]" + Console.RESET
+        val prjNbrNme = extractProjectName(state)
+        s"$manRmnd > $prjNbrNme > $exercise > "
+      }
+    )
+}

--- a/sbtLinearizeCommands/StudentKeys.scala.template
+++ b/sbtLinearizeCommands/StudentKeys.scala.template
@@ -1,0 +1,14 @@
+package sbtstudent
+
+/**
+ * Copyright © 2014 - 2017 Lightbend, Inc. All rights reserved. [http://www.lightbend.com]
+ */
+
+import sbt._
+import sbt.complete.Parser
+
+object StudentKeys {
+  val bookmarkKeyName = "bookmark"
+
+  val bookmark: AttributeKey[File] = AttributeKey[File](bookmarkKeyName)
+}

--- a/src/main/scala/com/lightbend/coursegentools/Helpers.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Helpers.scala
@@ -314,7 +314,7 @@ object Helpers {
     dumpStringToFile(s"alias boot = ;reload ;project ${config.studentifyModeClassic.studentifiedBaseFolder} ;iflast shell", new File(targetFolder, ".sbtrc").getPath)
   }
 
-  def addSbtStudentCommands(sbtStudentCommandsTemplateFolder: File, targetCourseFolder: File): Unit = {
+  def addSbtCommands(sbtStudentCommandsTemplateFolder: File, targetCourseFolder: File): Unit = {
     val projectFolder = new File(targetCourseFolder, "project")
     val moves = for {
       template <- sbtio.listFiles(sbtStudentCommandsTemplateFolder)

--- a/src/main/scala/com/lightbend/coursegentools/Linearize.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Linearize.scala
@@ -32,7 +32,7 @@ object Linearize {
 
     val cmdOptions = LinearizeCmdLineOptParse.parse(args)
     if (cmdOptions.isEmpty) System.exit(-1)
-    val LinearizeCmdOptions(masterRepo, linearizedOutputFolder, multiJVM, forceDeleteExistingDestinationFolder, configurationFile) = cmdOptions.get
+    val LinearizeCmdOptions(masterRepo, linearizedOutputFolder, multiJVM, forceDeleteExistingDestinationFolder, configurationFile, isADottyProject) = cmdOptions.get
 
     implicit val config: MasterSettings = new MasterSettings(masterRepo, configurationFile)
 
@@ -61,12 +61,12 @@ object Linearize {
     printNotification(s"Cleaned master repo: $cleanMasterRepo")
     val relativeCleanMasterRepo = new File(cleanMasterRepo, config.relativeSourceFolder)
     val linearizedProject = new File(linearizedOutputFolder, projectName)
-    val sbtStudentCommandsTemplateFolder = new File("sbtStudentCommands")
+    val sbtLinearizeCommandsTemplateFolder = new File("sbtLinearizeCommands")
 
     copyMaster(cleanMasterRepo, linearizedProject)
-    createStudentifiedBuildFile(linearizedProject, multiJVM, isADottyProject = false) // TODO: Add dotty support in Linearize
-    createBookmarkFile(exercises.head, linearizedProject)
-    addSbtStudentCommands(sbtStudentCommandsTemplateFolder, linearizedProject)
+    createStudentifiedBuildFile(linearizedProject, multiJVM, isADottyProject)
+    createBookmarkFile(config.studentifyModeClassic.studentifiedBaseFolder, linearizedProject)
+    addSbtCommands(sbtLinearizeCommandsTemplateFolder, linearizedProject)
     loadStudentSettings(masterRepo, linearizedProject)
     cleanUp(List(".git", "navigation.sbt"), linearizedProject)
 

--- a/src/main/scala/com/lightbend/coursegentools/LinearizeCmdLineOptParse.scala
+++ b/src/main/scala/com/lightbend/coursegentools/LinearizeCmdLineOptParse.scala
@@ -66,6 +66,13 @@ object LinearizeCmdLineOptParse {
           case (cfgFile, c) =>
             c.copy(configurationFile = Some(cfgFile))
         }
+
+      opt[Unit]("dotty")
+        .text("studentified repository is a Dotty project")
+        .abbr("dot")
+        .action { case (_, c) =>
+          c.copy(isADottyProject = true)
+        }
     }
 
     parser.parse(args, LinearizeCmdOptions())

--- a/src/main/scala/com/lightbend/coursegentools/Studentify.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Studentify.scala
@@ -59,7 +59,7 @@ object Studentify {
     createBookmarkFile(initialExercise, targetCourseFolder)
     createSbtRcFile(targetCourseFolder)
     createStudentifiedBuildFile(targetCourseFolder, multiJVM, isADottyProject)
-    addSbtStudentCommands(sbtStudentCommandsTemplateFolder, targetCourseFolder)
+    addSbtCommands(sbtStudentCommandsTemplateFolder, targetCourseFolder)
     loadStudentSettings(masterRepo, targetCourseFolder)
     cleanUp(config.studentifyFilesToCleanUp, targetCourseFolder)
     sbtio.delete(tmpDir)

--- a/src/main/scala/com/lightbend/coursegentools/package.scala
+++ b/src/main/scala/com/lightbend/coursegentools/package.scala
@@ -91,7 +91,8 @@ package object coursegentools {
                                  linearRepo: File = new File("."),
                                  multiJVM: Boolean = false,
                                  forceDeleteExistingDestinationFolder: Boolean = false,
-                                 configurationFile: Option[String] = None)
+                                 configurationFile: Option[String] = None,
+                                 isADottyProject: Boolean = false)
 
   case class DeLinearizeCmdOptions(masterRepo: File = new File("."),
                                    linearRepo: File = new File("."),


### PR DESCRIPTION
- Added support for linearization of a Dotty project
- A linearized project used to be not loadable in sbt. This is inconvenient
  as it prevents using an IDE (or sbt session) from being used during
  interactive rebasing of the linearized repo