### PR TITLE
Fix scripting in preparation of CI/CD enablement

### DIFF
--- a/cpCleanViaGit.sh
+++ b/cpCleanViaGit.sh
@@ -27,7 +27,7 @@ mkdir ${REMOTE_REPO}                              &&
 git init --bare $REMOTE_REPO                      &&
 # Get its path...
 cd $REMOTE_REPO                                   &&
-REPO=$( pwd )                                        &&
+REPO=$( pwd )                                     &&
 # Switch back to our master repo
 cd $MASTER                                        &&
 # ...and push whatever is in the current branch

--- a/cpCleanViaGit.sh
+++ b/cpCleanViaGit.sh
@@ -1,26 +1,43 @@
 #!/bin/bash
 
+# The path to the master repository
 MASTER=$1
+# A temp directory that has already been created for us...
 TMP_DIR=$2
+# The base name of the master repository
 REPO_NAME=$3
+# We're going to use this as the name of a folder that will be initialised
+# as a base gt repo. Next, we'll push the content of checked out branch
+# in the master repo into this repo.
+
 REMOTE_REPO=${REPO_NAME}.git
-CUR_DIR=`pwd`
+
+CUR_DIR=$( pwd )
 
 cd $MASTER
-MASTER=`pwd`
-CUR_BRANCH=`git branch | sed -e '/^ /d' -e 's/^..//'`
+MASTER=$( pwd )
+INIT_BRANCH=$( uuidgen )  # Name of branch that we'll be in on the cloned repo
 
-TMP_REMOTE=CMT-`uuidgen|tr '[:upper:]' '[:lower:]'`
+TMP_REMOTE=CMT-$( uuidgen|tr '[:upper:]' '[:lower:]' )
 
-cd $TMP_DIR                               &&
-mkdir ${REMOTE_REPO}                      &&
-git init --bare $REMOTE_REPO              &&
-cd $REMOTE_REPO                           &&
-REPO=`pwd`                                &&
-cd $MASTER                                &&
-git remote add $TMP_REMOTE $REPO          &&
-git push $TMP_REMOTE $CUR_BRANCH          &&
-cd $TMP_DIR                               &&
-git clone -b $CUR_BRANCH $REPO
+# In the temp directory...
+cd $TMP_DIR                                       &&
+# We create a bare git repo
+mkdir ${REMOTE_REPO}                              &&
+git init --bare $REMOTE_REPO                      &&
+# Get its path...
+cd $REMOTE_REPO                                   &&
+REPO=$( pwd )                                        &&
+# Switch back to our master repo
+cd $MASTER                                        &&
+# ...and push whatever is in the current branch
+git remote add $TMP_REMOTE $REPO                  &&
+# ... into the bare repo
+git push $TMP_REMOTE HEAD:refs/heads/$INIT_BRANCH &&
+# We finish off by cloning the copied repo and
+# check out a well named branch
+cd $TMP_DIR                                       &&
+git clone -b $INIT_BRANCH $REPO
 
+# Some housekeeping
 trap "cd $MASTER; git remote remove $TMP_REMOTE" 0

--- a/src/main/scala/com/lightbend/coursegentools/GenTests.scala
+++ b/src/main/scala/com/lightbend/coursegentools/GenTests.scala
@@ -21,7 +21,10 @@ object GenTests {
     val isADottyProjectOption = if (isADottyProject) "-dot" else ""
 
     val script: String =
-      s"""#!/bin/bash -e -o pipefail
+      s"""#!/bin/bash
+        |
+        |set -e
+        |set -o pipefail
         |
         |CMT_FOLDER=$cmtFolder # This should become a script argument at some stage
         |


### PR DESCRIPTION
- Github Actions require setting bash fast fail options (-e and
  -o fastfail) to be set one-by-one
- Fixing of the script that makes a clean copy of a master repo
  to also work insode of a Github Action plugin
- Add some clarifications to the copy script